### PR TITLE
Add XML docs and simplify enum usage in test methods

### DIFF
--- a/ProjetoTCCBackend.Unit.Test/Services/CompetitionRankingServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/CompetitionRankingServiceTests.cs
@@ -183,7 +183,15 @@ namespace ProjetoTCCBackend.Unit.Test.Services
         {
             var competition = new Competition { Id = 1, SubmissionPenalty = TimeSpan.FromMinutes(10) };
             var group = new Group { Id = 1, Name = "Test", LeaderId = "u1", Users = new List<User> { new User { Id = "u1", Email = "t@t.com", Name = "T", JoinYear = 2024 } } };
-            var exerciseAttempt = new GroupExerciseAttempt { Code = "", Id = 3, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = false };
+            var exerciseAttempt = new GroupExerciseAttempt
+            {
+                Code = "",
+                Id = 3,
+                GroupId = 1,
+                CompetitionId = 1,
+                ExerciseId = 1,
+                Accepted = false
+            };
             var attempts = new List<GroupExerciseAttempt>
             {
                 new GroupExerciseAttempt { Code = "", Id = 1, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = false },

--- a/ProjetoTCCBackend.Unit.Test/Services/CompetitionRankingServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/CompetitionRankingServiceTests.cs
@@ -156,7 +156,22 @@ namespace ProjetoTCCBackend.Unit.Test.Services
         public async Task UpdateRanking_CalculatesMultipleAttempts()
         {
             var competition = new Competition { Id = 1, SubmissionPenalty = TimeSpan.FromMinutes(20) };
-            var group = new Group { Id = 1, Name = "Test", LeaderId = "u1", Users = new List<User> { new User { Id = "u1", Email = "t@t.com", Name = "T", JoinYear = 2024 } } };
+            var group = new Group
+            {
+                Id = 1,
+                Name = "Test",
+                LeaderId = "u1",
+                Users = new List<User>
+                {
+                    new User
+                    {
+                        Id = "u1",
+                        Email = "t@t.com",
+                        Name = "T",
+                        JoinYear = 2024
+                    }
+                }
+            };
             var exerciseAttempt = new GroupExerciseAttempt { Code = "", Id = 5, GroupId = 1, CompetitionId = 1, ExerciseId = 2, Accepted = false };
             var attempts = new List<GroupExerciseAttempt>
             {

--- a/ProjetoTCCBackend.Unit.Test/Services/CompetitionRankingServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/CompetitionRankingServiceTests.cs
@@ -83,12 +83,62 @@ namespace ProjetoTCCBackend.Unit.Test.Services
         [Fact]
         public async Task UpdateRanking_UpdatesExistingRanking()
         {
-            var competition = new Competition { Id = 1, SubmissionPenalty = TimeSpan.FromMinutes(5) };
-            var group = new Group { Id = 1, Name = "Test", LeaderId = "u1", Users = new List<User> { new User { Id = "u1", Email = "t@t.com", Name = "T", JoinYear = 2024 } } };
-            var exerciseAttempt = new GroupExerciseAttempt { Code = "", Id = 2, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = true };
-            var attempts = new List<GroupExerciseAttempt> { new GroupExerciseAttempt { Code = "", Id = 1, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = false }, exerciseAttempt }.AsQueryable();
-            var existingRanking = new CompetitionRanking { Id = 1, CompetitionId = 1, GroupId = 1, Points = 0, Penalty = 5, RankOrder = 1 };
-            var rankings = new List<CompetitionRanking> { existingRanking }.AsQueryable();
+            var competition = new Competition
+            {
+                Id = 1,
+                SubmissionPenalty = TimeSpan.FromMinutes(5)
+            };
+            var group = new Group
+            {
+                Id = 1,
+                Name = "Test",
+                LeaderId = "u1",
+                Users = new List<User>
+                {
+                    new User
+                    {
+                        Id = "u1",
+                        Email = "t@t.com",
+                        Name = "T",
+                        JoinYear = 2024
+                    }
+                }
+            };
+            var exerciseAttempt = new GroupExerciseAttempt
+            {
+                Code = "",
+                Id = 2,
+                GroupId = 1,
+                CompetitionId = 1,
+                ExerciseId = 1,
+                Accepted = true
+            };
+            var attempts = new List<GroupExerciseAttempt>
+            {
+                new GroupExerciseAttempt
+                {
+                    Code = "",
+                    Id = 1,
+                    GroupId = 1,
+                    CompetitionId = 1,
+                    ExerciseId = 1,
+                    Accepted = false
+                },
+                exerciseAttempt
+            }.AsQueryable();
+            var existingRanking = new CompetitionRanking
+            {
+                Id = 1,
+                CompetitionId = 1,
+                GroupId = 1,
+                Points = 0,
+                Penalty = 5,
+                RankOrder = 1
+            };
+            var rankings = new List<CompetitionRanking>
+            {
+                existingRanking
+            }.AsQueryable();
 
             _groupExerciseAttemptRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<GroupExerciseAttempt, bool>>>())).Returns(attempts);
             _competitionRankingRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<CompetitionRanking, bool>>>())).Returns(rankings);

--- a/ProjetoTCCBackend.Unit.Test/Services/CompetitionRankingServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/CompetitionRankingServiceTests.cs
@@ -1,18 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Moq;
-using Xunit;
-using ProjetoTccBackend.Services;
-using ProjetoTccBackend.Repositories.Interfaces;
-using ProjetoTccBackend.Models;
 using ProjetoTccBackend.Database;
-using ProjetoTccBackend.Services.Interfaces;
-using Microsoft.Extensions.Logging;
-using Microsoft.EntityFrameworkCore;
+using ProjetoTccBackend.Models;
+using ProjetoTccBackend.Repositories.Interfaces;
+using ProjetoTccBackend.Services;
+using Xunit;
 
 namespace ProjetoTCCBackend.Unit.Test.Services
 {
     public class CompetitionRankingServiceTests
     {
-        
-        
+        private Mock<ICompetitionRankingRepository> _competitionRankingRepositoryMock;
+        private Mock<IGroupExerciseAttemptRepository> _groupExerciseAttemptRepositoryMock;
+        private TccDbContext? _dbContext;
+
+        public CompetitionRankingServiceTests()
+        {
+            _competitionRankingRepositoryMock = new Mock<ICompetitionRankingRepository>();
+            _groupExerciseAttemptRepositoryMock = new Mock<IGroupExerciseAttemptRepository>();
+        }
+
+        private CompetitionRankingService CreateService()
+        {
+            _dbContext = DbContextTestFactory.Create($"TestDb_{Guid.NewGuid()}");
+            return new CompetitionRankingService(
+                _competitionRankingRepositoryMock.Object,
+                _groupExerciseAttemptRepositoryMock.Object,
+                _dbContext
+            );
+        }
+
+        [Fact]
+        public async Task UpdateRanking_CreatesNewRanking_WhenGroupNotInRanking()
+        {
+            var competition = new Competition
+            {
+                Id = 1,
+                Name = "Test Competition",
+                SubmissionPenalty = TimeSpan.FromMinutes(10),
+            };
+
+            var group = new Group
+            {
+                Id = 1,
+                Name = "Test Group",
+                LeaderId = "user1",
+                Users = new List<User>
+                {
+                    new User { Id = "user1", Email = "user1@test.com", Name = "User 1", JoinYear = 2024 },
+                },
+            };
+
+            var exerciseAttempt = new GroupExerciseAttempt
+            {
+                Code = "",
+                Id = 1,
+                GroupId = 1,
+                CompetitionId = 1,
+                ExerciseId = 1,
+                Accepted = true,
+            };
+
+            var attempts = new List<GroupExerciseAttempt> { exerciseAttempt }.AsQueryable();
+            var emptyRankings = new List<CompetitionRanking>().AsQueryable();
+
+            _groupExerciseAttemptRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<GroupExerciseAttempt, bool>>>())).Returns(attempts);
+            _competitionRankingRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<CompetitionRanking, bool>>>())).Returns(emptyRankings);
+
+            var service = CreateService();
+            var result = await service.UpdateRanking(competition, group, exerciseAttempt);
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Points);
+            Assert.Equal(10, result.Penalty);
+            Assert.Equal(1, result.RankOrder);
+            _competitionRankingRepositoryMock.Verify(r => r.Add(It.IsAny<CompetitionRanking>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateRanking_UpdatesExistingRanking()
+        {
+            var competition = new Competition { Id = 1, SubmissionPenalty = TimeSpan.FromMinutes(5) };
+            var group = new Group { Id = 1, Name = "Test", LeaderId = "u1", Users = new List<User> { new User { Id = "u1", Email = "t@t.com", Name = "T", JoinYear = 2024 } } };
+            var exerciseAttempt = new GroupExerciseAttempt { Code = "", Id = 2, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = true };
+            var attempts = new List<GroupExerciseAttempt> { new GroupExerciseAttempt { Code = "", Id = 1, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = false }, exerciseAttempt }.AsQueryable();
+            var existingRanking = new CompetitionRanking { Id = 1, CompetitionId = 1, GroupId = 1, Points = 0, Penalty = 5, RankOrder = 1 };
+            var rankings = new List<CompetitionRanking> { existingRanking }.AsQueryable();
+
+            _groupExerciseAttemptRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<GroupExerciseAttempt, bool>>>())).Returns(attempts);
+            _competitionRankingRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<CompetitionRanking, bool>>>())).Returns(rankings);
+
+            var service = CreateService();
+            var result = await service.UpdateRanking(competition, group, exerciseAttempt);
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Points);
+            Assert.Equal(10, result.Penalty);
+            _competitionRankingRepositoryMock.Verify(r => r.Update(It.IsAny<CompetitionRanking>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateRanking_CalculatesMultipleAttempts()
+        {
+            var competition = new Competition { Id = 1, SubmissionPenalty = TimeSpan.FromMinutes(20) };
+            var group = new Group { Id = 1, Name = "Test", LeaderId = "u1", Users = new List<User> { new User { Id = "u1", Email = "t@t.com", Name = "T", JoinYear = 2024 } } };
+            var exerciseAttempt = new GroupExerciseAttempt { Code = "", Id = 5, GroupId = 1, CompetitionId = 1, ExerciseId = 2, Accepted = false };
+            var attempts = new List<GroupExerciseAttempt>
+            {
+                new GroupExerciseAttempt { Code = "", Id = 1, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = false },
+                new GroupExerciseAttempt { Code = "", Id = 2, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = false },
+                new GroupExerciseAttempt { Code = "", Id = 3, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = true },
+                new GroupExerciseAttempt { Code = "", Id = 4, GroupId = 1, CompetitionId = 1, ExerciseId = 2, Accepted = false },
+                exerciseAttempt,
+            }.AsQueryable();
+
+            _groupExerciseAttemptRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<GroupExerciseAttempt, bool>>>())).Returns(attempts);
+            _competitionRankingRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<CompetitionRanking, bool>>>())).Returns(new List<CompetitionRanking>().AsQueryable());
+
+            var service = CreateService();
+            var result = await service.UpdateRanking(competition, group, exerciseAttempt);
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Points);
+            Assert.Equal(100, result.Penalty);
+        }
+
+        [Fact]
+        public async Task UpdateRanking_ReturnsZeroPoints_WhenNoAccepted()
+        {
+            var competition = new Competition { Id = 1, SubmissionPenalty = TimeSpan.FromMinutes(10) };
+            var group = new Group { Id = 1, Name = "Test", LeaderId = "u1", Users = new List<User> { new User { Id = "u1", Email = "t@t.com", Name = "T", JoinYear = 2024 } } };
+            var exerciseAttempt = new GroupExerciseAttempt { Code = "", Id = 3, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = false };
+            var attempts = new List<GroupExerciseAttempt>
+            {
+                new GroupExerciseAttempt { Code = "", Id = 1, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = false },
+                new GroupExerciseAttempt { Code = "", Id = 2, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = false },
+                exerciseAttempt,
+            }.AsQueryable();
+
+            _groupExerciseAttemptRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<GroupExerciseAttempt, bool>>>())).Returns(attempts);
+            _competitionRankingRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<CompetitionRanking, bool>>>())).Returns(new List<CompetitionRanking>().AsQueryable());
+
+            var service = CreateService();
+            var result = await service.UpdateRanking(competition, group, exerciseAttempt);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.Points);
+            Assert.Equal(30, result.Penalty);
+        }
+
+        [Fact]
+        public async Task UpdateRanking_IncludesGroupInfo()
+        {
+            var competition = new Competition { Id = 1, SubmissionPenalty = TimeSpan.FromMinutes(10) };
+            var group = new Group { Id = 1, Name = "Test Group", LeaderId = "u1", Users = new List<User> { new User { Id = "u1", Email = "a@a.com", Name = "A", JoinYear = 2024 }, new User { Id = "u2", Email = "b@b.com", Name = "B", JoinYear = 2023 } } };
+            var exerciseAttempt = new GroupExerciseAttempt { Code = "", Id = 1, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = true };
+
+            _groupExerciseAttemptRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<GroupExerciseAttempt, bool>>>())).Returns(new List<GroupExerciseAttempt> { exerciseAttempt }.AsQueryable());
+            _competitionRankingRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<CompetitionRanking, bool>>>())).Returns(new List<CompetitionRanking>().AsQueryable());
+
+            var service = CreateService();
+            var result = await service.UpdateRanking(competition, group, exerciseAttempt);
+
+            Assert.NotNull(result.Group);
+            Assert.Equal(1, result.Group.Id);
+            Assert.Equal("Test Group", result.Group.Name);
+            Assert.Equal(2, result.Group.Users.Count);
+        }
+
+        [Fact]
+        public async Task UpdateRanking_IncludesExerciseAttempts()
+        {
+            var competition = new Competition { Id = 1, SubmissionPenalty = TimeSpan.FromMinutes(10) };
+            var group = new Group { Id = 1, Name = "Test", LeaderId = "u1", Users = new List<User> { new User { Id = "u1", Email = "t@t.com", Name = "T", JoinYear = 2024 } } };
+            var exerciseAttempt = new GroupExerciseAttempt { Code = "", Id = 4, GroupId = 1, CompetitionId = 1, ExerciseId = 2, Accepted = false };
+            var attempts = new List<GroupExerciseAttempt>
+            {
+                new GroupExerciseAttempt { Code = "", Id = 1, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = true },
+                new GroupExerciseAttempt { Code = "", Id = 2, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = false },
+                new GroupExerciseAttempt { Code = "", Id = 3, GroupId = 1, CompetitionId = 1, ExerciseId = 1, Accepted = false },
+                exerciseAttempt,
+            }.AsQueryable();
+
+            _groupExerciseAttemptRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<GroupExerciseAttempt, bool>>>())).Returns(attempts);
+            _competitionRankingRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<CompetitionRanking, bool>>>())).Returns(new List<CompetitionRanking>().AsQueryable());
+
+            var service = CreateService();
+            var result = await service.UpdateRanking(competition, group, exerciseAttempt);
+
+            Assert.NotNull(result.ExerciseAttempts);
+            Assert.Equal(2, result.ExerciseAttempts.Count);
+            var ex1 = result.ExerciseAttempts.FirstOrDefault(e => e.ExerciseId == 1);
+            Assert.NotNull(ex1);
+            Assert.Equal(3, ex1.Attempts);
+        }
     }
 }

--- a/ProjetoTCCBackend.Unit.Test/Services/CompetitionServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/CompetitionServiceTests.cs
@@ -1,16 +1,568 @@
-using Moq;
-using Xunit;
-using ProjetoTccBackend.Services;
-using ProjetoTccBackend.Repositories.Interfaces;
-using ProjetoTccBackend.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
-using ProjetoTccBackend.Database;
-using ProjetoTccBackend.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using MockQueryable.Moq;
+using Moq;
+using ProjetoTccBackend.Database;
+using ProjetoTccBackend.Database.Requests.Competition;
+using ProjetoTccBackend.Enums.Competition;
+using ProjetoTccBackend.Exceptions;
+using ProjetoTccBackend.Models;
+using ProjetoTccBackend.Repositories.Interfaces;
+using ProjetoTccBackend.Services;
+using ProjetoTccBackend.Services.Interfaces;
+using Xunit;
 
 namespace ProjetoTCCBackend.Unit.Test.Services
 {
     public class CompetitionServiceTests
     {
+        private Mock<IUserService> _userServiceMock;
+        private Mock<ICompetitionRepository> _competitionRepositoryMock;
+        private Mock<IGroupInCompetitionRepository> _groupInCompetitionRepositoryMock;
+        private Mock<ICompetitionRankingRepository> _competitionRankingRepositoryMock;
+        private Mock<IQuestionRepository> _questionRepositoryMock;
+        private Mock<IAnswerRepository> _answerRepositoryMock;
+        private Mock<IExerciseInCompetitionRepository> _exerciseInCompetitionRepositoryMock;
+        private Mock<ICompetitionStateService> _competitionStateServiceMock;
+        private Mock<ILogger<CompetitionService>> _loggerMock;
+        private TccDbContext? _dbContext;
+
+        public CompetitionServiceTests()
+        {
+            _userServiceMock = new Mock<IUserService>();
+            _competitionRepositoryMock = new Mock<ICompetitionRepository>();
+            _groupInCompetitionRepositoryMock = new Mock<IGroupInCompetitionRepository>();
+            _competitionRankingRepositoryMock = new Mock<ICompetitionRankingRepository>();
+            _questionRepositoryMock = new Mock<IQuestionRepository>();
+            _answerRepositoryMock = new Mock<IAnswerRepository>();
+            _exerciseInCompetitionRepositoryMock = new Mock<IExerciseInCompetitionRepository>();
+            _competitionStateServiceMock = new Mock<ICompetitionStateService>();
+            _loggerMock = new Mock<ILogger<CompetitionService>>();
+        }
+
+        private CompetitionService CreateService()
+        {
+            _dbContext = DbContextTestFactory.Create($"TestDb_{Guid.NewGuid()}");
+            return new CompetitionService(
+                _userServiceMock.Object,
+                _competitionRepositoryMock.Object,
+                _groupInCompetitionRepositoryMock.Object,
+                _competitionRankingRepositoryMock.Object,
+                _questionRepositoryMock.Object,
+                _answerRepositoryMock.Object,
+                _exerciseInCompetitionRepositoryMock.Object,
+                _competitionStateServiceMock.Object,
+                _dbContext,
+                _loggerMock.Object
+            );
+        }
+
+        [Fact]
+        public async Task CreateCompetition_CreatesSuccessfully_WhenNoConflict()
+        {
+            // Arrange
+            var request = new CompetitionRequest
+            {
+                Name = "Test Competition",
+                StartTime = DateTime.UtcNow.AddDays(1),
+                Duration = TimeSpan.FromHours(3),
+                ExerciseIds = new List<int> { 1, 2, 3 },
+                MaxExercises = 10,
+                MaxSubmissionSize = 1000,
+                SubmissionPenalty = TimeSpan.FromMinutes(5),
+                BlockSubmissions = TimeSpan.FromHours(2),
+                StopRanking = TimeSpan.FromHours(2),
+                Description = "Test description",
+                MaxMembers = 3,
+                StartInscriptions = DateTime.UtcNow,
+                EndInscriptions = DateTime.UtcNow.AddHours(23),
+            };
+
+            var emptyCompetitions = new List<Competition>().AsQueryable();
+            _competitionRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<Competition, bool>>>()))
+                .Returns(emptyCompetitions);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.CreateCompetition(request);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Test Competition", result.Name);
+            _competitionRepositoryMock.Verify(r => r.Add(It.IsAny<Competition>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateCompetition_ThrowsException_WhenCompetitionExistsOnSameDate()
+        {
+            // Arrange
+            var startTime = DateTime.UtcNow.AddDays(1);
+            var request = new CompetitionRequest
+            {
+                Name = "Test Competition",
+                StartTime = startTime,
+                Duration = TimeSpan.FromHours(3),
+                ExerciseIds = new List<int>(),
+                MaxExercises = 10,
+                MaxSubmissionSize = 1000,
+                SubmissionPenalty = TimeSpan.FromMinutes(5),
+                BlockSubmissions = TimeSpan.FromHours(2),
+                StopRanking = TimeSpan.FromHours(2),
+                Description = "Test",
+                MaxMembers = 3,
+                StartInscriptions = DateTime.UtcNow,
+                EndInscriptions = DateTime.UtcNow.AddHours(23),
+            };
+
+            var existingCompetition = new Competition
+            {
+                Id = 1,
+                Name = "Existing Competition",
+                StartTime = startTime,
+            };
+
+            var competitions = new List<Competition> { existingCompetition }.AsQueryable();
+            _competitionRepositoryMock.Setup(r => r.Find(It.IsAny<System.Linq.Expressions.Expression<Func<Competition, bool>>>()))
+                .Returns(competitions);
+
+            var service = CreateService();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ExistentCompetitionException>(
+                () => service.CreateCompetition(request)
+            );
+        }
+
+        [Fact]
+        public async Task GetCurrentCompetition_ReturnsCompetition_WhenOngoing()
+        {
+            // Arrange
+            var currentTime = DateTime.UtcNow;
+            var competition = new Competition
+            {
+                Id = 1,
+                Name = "Current Competition",
+                StartTime = currentTime.AddHours(-1),
+                EndTime = currentTime.AddHours(2),
+                StartInscriptions = currentTime.AddHours(-2),
+                Status = CompetitionStatus.Ongoing,
+                Exercices = new List<Exercise>(),
+                Groups = new List<Group>(),
+                CompetitionRankings = new List<CompetitionRanking>(),
+                GroupInCompetitions = new List<GroupInCompetition>(),
+            };
+
+            var competitions = new List<Competition> { competition }.AsQueryable().BuildMock();
+            _competitionRepositoryMock.Setup(r => r.Query()).Returns(competitions);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.GetCurrentCompetition();
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Id);
+            Assert.Equal(CompetitionStatus.Ongoing, result.Status);
+        }
+
+        [Fact]
+        public async Task GetCurrentCompetition_ReturnsNull_WhenNoOngoingCompetition()
+        {
+            // Arrange
+            var emptyCompetitions = new List<Competition>().AsQueryable().BuildMock();
+            _competitionRepositoryMock.Setup(r => r.Query()).Returns(emptyCompetitions);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.GetCurrentCompetition();
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task OpenCompetitionInscriptionsAsync_ChangesStatus_ToOpenInscriptions()
+        {
+            // Arrange
+            var competition = new Competition
+            {
+                Id = 1,
+                Name = "Test Competition",
+                Status = CompetitionStatus.Pending,
+            };
+
+            var service = CreateService();
+
+            // Act
+            await service.OpenCompetitionInscriptionsAsync(competition);
+
+            // Assert
+            Assert.Equal(CompetitionStatus.OpenInscriptions, competition.Status);
+            _competitionRepositoryMock.Verify(r => r.Update(competition), Times.Once);
+        }
+
+        [Fact]
+        public async Task StartCompetitionAsync_ChangesStatus_ToOngoing()
+        {
+            // Arrange
+            var competition = new Competition
+            {
+                Id = 1,
+                Name = "Test Competition",
+                Status = CompetitionStatus.ClosedInscriptions,
+            };
+
+            var service = CreateService();
+
+            // Act
+            await service.StartCompetitionAsync(competition);
+
+            // Assert
+            Assert.Equal(CompetitionStatus.Ongoing, competition.Status);
+            _competitionRepositoryMock.Verify(r => r.Update(competition), Times.Once);
+        }
+
+        [Fact]
+        public async Task EndCompetitionAsync_ChangesStatus_ToFinished()
+        {
+            // Arrange
+            var competition = new Competition
+            {
+                Id = 1,
+                Name = "Test Competition",
+                Status = CompetitionStatus.Ongoing,
+            };
+
+            var service = CreateService();
+
+            // Act
+            await service.EndCompetitionAsync(competition);
+
+            // Assert
+            Assert.Equal(CompetitionStatus.Finished, competition.Status);
+            _competitionRepositoryMock.Verify(r => r.Update(competition), Times.Once);
+            _competitionStateServiceMock.Verify(s => s.SignalNoActiveCompetitions(), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetOpenCompetitionsAsync_ReturnsOnlyNonFinished()
+        {
+            // Arrange
+            var competitions = new List<Competition>
+            {
+                new Competition { Id = 1, Name = "Ongoing", Status = CompetitionStatus.Ongoing },
+                new Competition { Id = 2, Name = "Pending", Status = CompetitionStatus.Pending },
+                new Competition { Id = 3, Name = "Finished", Status = CompetitionStatus.Finished },
+            }.AsQueryable().BuildMock();
+
+            _competitionRepositoryMock.Setup(r => r.Query()).Returns(competitions);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.GetOpenCompetitionsAsync();
+
+            // Assert
+            Assert.Equal(2, result.Count);
+            Assert.DoesNotContain(result, c => c.Status == CompetitionStatus.Finished);
+        }
+
+        [Fact]
+        public async Task InscribeGroupInCompetition_ThrowsException_WhenUserNotLeader()
+        {
+            // Arrange
+            var loggedUser = new User
+            {
+                Id = "user1",
+                GroupId = 1,
+                Group = new Group
+                {
+                    Id = 1,
+                    LeaderId = "user2", // Different user
+                    Users = new List<User>(),
+                },
+            };
+
+            var request = new InscribeGroupToCompetitionRequest
+            {
+                CompetitionId = 1,
+                GroupId = 1,
+            };
+
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+
+            var service = CreateService();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<UserIsNotLeaderException>(
+                () => service.InscribeGroupInCompetition(request)
+            );
+        }
+
+        [Fact]
+        public async Task InscribeGroupInCompetition_ThrowsException_WhenCompetitionNotFound()
+        {
+            // Arrange
+            var loggedUser = new User
+            {
+                Id = "user1",
+                GroupId = 1,
+                Group = new Group
+                {
+                    Id = 1,
+                    LeaderId = "user1",
+                    Users = new List<User> { new User { Id = "user1" } },
+                },
+            };
+
+            var request = new InscribeGroupToCompetitionRequest
+            {
+                CompetitionId = 999,
+                GroupId = 1,
+            };
+
+            var emptyCompetitions = new List<Competition>().AsQueryable().BuildMock();
+            _competitionRepositoryMock.Setup(r => r.Query()).Returns(emptyCompetitions);
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+
+            var service = CreateService();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<NotExistentCompetitionException>(
+                () => service.InscribeGroupInCompetition(request)
+            );
+        }
+
+        [Fact]
+        public async Task InscribeGroupInCompetition_ThrowsException_WhenAlreadyInscribed()
+        {
+            // Arrange
+            var loggedUser = new User
+            {
+                Id = "user1",
+                GroupId = 1,
+                Group = new Group
+                {
+                    Id = 1,
+                    LeaderId = "user1",
+                    Users = new List<User> { new User { Id = "user1" } },
+                },
+            };
+
+            var competition = new Competition
+            {
+                Id = 1,
+                Name = "Test Competition",
+                StartInscriptions = DateTime.UtcNow.AddHours(-1),
+                EndInscriptions = DateTime.UtcNow.AddHours(1),
+                MaxMembers = 3,
+                GroupInCompetitions = new List<GroupInCompetition>
+                {
+                    new GroupInCompetition { CompetitionId = 1, GroupId = 1 },
+                },
+            };
+
+            var competitions = new List<Competition> { competition }.AsQueryable().BuildMock();
+            _competitionRepositoryMock.Setup(r => r.Query()).Returns(competitions);
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+
+            var request = new InscribeGroupToCompetitionRequest
+            {
+                CompetitionId = 1,
+                GroupId = 1,
+            };
+
+            var service = CreateService();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<AlreadyInCompetitionException>(
+                () => service.InscribeGroupInCompetition(request)
+            );
+        }
+
+        [Fact]
+        public async Task InscribeGroupInCompetition_ThrowsException_WhenTooManyMembers()
+        {
+            // Arrange
+            var users = new List<User>
+            {
+                new User { Id = "user1" },
+                new User { Id = "user2" },
+                new User { Id = "user3" },
+                new User { Id = "user4" },
+            };
+
+            var loggedUser = new User
+            {
+                Id = "user1",
+                GroupId = 1,
+                Group = new Group
+                {
+                    Id = 1,
+                    LeaderId = "user1",
+                    Users = users,
+                },
+            };
+
+            var competition = new Competition
+            {
+                Id = 1,
+                Name = "Test Competition",
+                StartInscriptions = DateTime.UtcNow.AddHours(-1),
+                EndInscriptions = DateTime.UtcNow.AddHours(1),
+                MaxMembers = 3, // Only 3 members allowed
+                GroupInCompetitions = new List<GroupInCompetition>(),
+            };
+
+            var competitions = new List<Competition> { competition }.AsQueryable().BuildMock();
+            _competitionRepositoryMock.Setup(r => r.Query()).Returns(competitions);
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+
+            var request = new InscribeGroupToCompetitionRequest
+            {
+                CompetitionId = 1,
+                GroupId = 1,
+            };
+
+            var service = CreateService();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<MaxMembersExceededException>(
+                () => service.InscribeGroupInCompetition(request)
+            );
+        }
+
+        [Fact]
+        public async Task BlockGroupInCompetition_ReturnsTrue_WhenGroupFound()
+        {
+            // Arrange
+            var groupInCompetition = new GroupInCompetition
+            {
+                GroupId = 1,
+                CompetitionId = 1,
+                Blocked = false,
+            };
+
+            _dbContext = DbContextTestFactory.Create($"TestDb_{Guid.NewGuid()}");
+            _dbContext.GroupsInCompetitions.Add(groupInCompetition);
+            await _dbContext.SaveChangesAsync();
+
+            var service = new CompetitionService(
+                _userServiceMock.Object,
+                _competitionRepositoryMock.Object,
+                _groupInCompetitionRepositoryMock.Object,
+                _competitionRankingRepositoryMock.Object,
+                _questionRepositoryMock.Object,
+                _answerRepositoryMock.Object,
+                _exerciseInCompetitionRepositoryMock.Object,
+                _competitionStateServiceMock.Object,
+                _dbContext,
+                _loggerMock.Object
+            );
+
+            var request = new BlockGroupSubmissionRequest
+            {
+                GroupId = 1,
+                CompetitionId = 1,
+            };
+
+            // Act
+            var result = await service.BlockGroupInCompetition(request);
+
+            // Assert
+            Assert.True(result);
+            Assert.True(groupInCompetition.Blocked);
+        }
+
+        [Fact]
+        public async Task BlockGroupInCompetition_ReturnsFalse_WhenGroupNotFound()
+        {
+            // Arrange
+            var service = CreateService();
+            var request = new BlockGroupSubmissionRequest
+            {
+                GroupId = 999,
+                CompetitionId = 999,
+            };
+
+            // Act
+            var result = await service.BlockGroupInCompetition(request);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task StopCompetitionAsync_ReturnsTrue_AndStopsCompetition()
+        {
+            // Arrange
+            var competition = new Competition
+            {
+                Id = 1,
+                Name = "Test Competition",
+                Status = CompetitionStatus.Ongoing,
+                EndTime = DateTime.UtcNow.AddHours(1),
+            };
+
+            var competitions = new List<Competition> { competition }.AsQueryable().BuildMock();
+            _competitionRepositoryMock.Setup(r => r.Query()).Returns(competitions);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.StopCompetitionAsync(1);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(CompetitionStatus.Finished, competition.Status);
+            Assert.True(competition.EndTime <= DateTime.UtcNow);
+            _competitionRepositoryMock.Verify(r => r.Update(competition), Times.Once);
+        }
+
+        [Fact]
+        public async Task StopCompetitionAsync_ReturnsFalse_WhenCompetitionNotFound()
+        {
+            // Arrange
+            var emptyCompetitions = new List<Competition>().AsQueryable().BuildMock();
+            _competitionRepositoryMock.Setup(r => r.Query()).Returns(emptyCompetitions);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.StopCompetitionAsync(999);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task StopCompetitionAsync_ReturnsFalse_WhenAlreadyFinished()
+        {
+            // Arrange
+            var competition = new Competition
+            {
+                Id = 1,
+                Name = "Test Competition",
+                Status = CompetitionStatus.Finished,
+            };
+
+            var competitions = new List<Competition> { competition }.AsQueryable().BuildMock();
+            _competitionRepositoryMock.Setup(r => r.Query()).Returns(competitions);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.StopCompetitionAsync(1);
+
+            // Assert
+            Assert.False(result);
+        }
     }
 }

--- a/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
@@ -22,7 +22,7 @@ namespace ProjetoTCCBackend.Unit.Test.Services
     {
         private readonly Mock<IUserService> _userServiceMock;
         private readonly Mock<IUserRepository> _userRepositoryMock;
-        private Mock<IGroupRepository> _groupRepositoryMock;
+        private readonly Mock<IGroupRepository> _groupRepositoryMock;
         private Mock<IGroupInviteService> _groupInviteServiceMock;
         private Mock<ILogger<GroupService>> _loggerMock;
         private TccDbContext? _dbContext;

--- a/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
@@ -24,7 +24,7 @@ namespace ProjetoTCCBackend.Unit.Test.Services
         private readonly Mock<IUserRepository> _userRepositoryMock;
         private readonly Mock<IGroupRepository> _groupRepositoryMock;
         private readonly Mock<IGroupInviteService> _groupInviteServiceMock;
-        private Mock<ILogger<GroupService>> _loggerMock;
+        private readonly Mock<ILogger<GroupService>> _loggerMock;
         private TccDbContext? _dbContext;
 
         public GroupServiceTests()

--- a/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
@@ -67,7 +67,7 @@ namespace ProjetoTCCBackend.Unit.Test.Services
                 UserRAs = null
             };
 
-            // Simula o grupo após ser salvo no banco com ID gerado
+            // Simulates the group after being saved to the database with generated ID
             var savedGroup = new Group
             {
                 Id = 1,
@@ -77,10 +77,10 @@ namespace ProjetoTCCBackend.Unit.Test.Services
                 GroupInvites = new List<GroupInvite>()
             };
 
-            // Primeira chamada: verificar se usuário já tem grupo (retorna vazio)
+            // First call: check if user already has a group (returns empty)
             var emptyGroupsQuery = new List<Group>().AsQueryable().BuildMock();
             
-            // Segunda chamada: buscar o grupo recém-criado
+            // Second call: fetch the newly created group
             var groupQueryWithNew = new List<Group> { savedGroup }.AsQueryable().BuildMock();
 
             _groupRepositoryMock.SetupSequence(r => r.Query())
@@ -89,7 +89,7 @@ namespace ProjetoTCCBackend.Unit.Test.Services
 
             _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
 
-            // Mock do Add para setar o ID do grupo
+            // Mock the Add to set the group ID
             _groupRepositoryMock
                 .Setup(r => r.Add(It.IsAny<Group>()))
                 .Callback<Group>(g => g.Id = 1);

--- a/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
@@ -20,7 +20,7 @@ namespace ProjetoTCCBackend.Unit.Test.Services
 {
     public class GroupServiceTests
     {
-        private Mock<IUserService> _userServiceMock;
+        private readonly Mock<IUserService> _userServiceMock;
         private Mock<IUserRepository> _userRepositoryMock;
         private Mock<IGroupRepository> _groupRepositoryMock;
         private Mock<IGroupInviteService> _groupInviteServiceMock;

--- a/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
@@ -23,7 +23,7 @@ namespace ProjetoTCCBackend.Unit.Test.Services
         private readonly Mock<IUserService> _userServiceMock;
         private readonly Mock<IUserRepository> _userRepositoryMock;
         private readonly Mock<IGroupRepository> _groupRepositoryMock;
-        private Mock<IGroupInviteService> _groupInviteServiceMock;
+        private readonly Mock<IGroupInviteService> _groupInviteServiceMock;
         private Mock<ILogger<GroupService>> _loggerMock;
         private TccDbContext? _dbContext;
 

--- a/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
@@ -1,17 +1,651 @@
-using Moq;
-using Xunit;
-using ProjetoTccBackend.Services;
-using ProjetoTccBackend.Repositories.Interfaces;
-using ProjetoTccBackend.Models;
-using ProjetoTccBackend.Database;
-using ProjetoTccBackend.Services.Interfaces;
-using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using MockQueryable.Moq;
+using Moq;
+using ProjetoTccBackend.Database;
+using ProjetoTccBackend.Database.Requests.Group;
+using ProjetoTccBackend.Database.Responses.Group;
+using ProjetoTccBackend.Exceptions.Group;
+using ProjetoTccBackend.Models;
+using ProjetoTccBackend.Repositories.Interfaces;
+using ProjetoTccBackend.Services;
+using ProjetoTccBackend.Services.Interfaces;
+using Xunit;
 
 namespace ProjetoTCCBackend.Unit.Test.Services
 {
     public class GroupServiceTests
     {
-        
+        private Mock<IUserService> _userServiceMock;
+        private Mock<IUserRepository> _userRepositoryMock;
+        private Mock<IGroupRepository> _groupRepositoryMock;
+        private Mock<IGroupInviteService> _groupInviteServiceMock;
+        private Mock<ILogger<GroupService>> _loggerMock;
+        private TccDbContext? _dbContext;
+
+        public GroupServiceTests()
+        {
+            _userServiceMock = new Mock<IUserService>();
+            _userRepositoryMock = new Mock<IUserRepository>();
+            _groupRepositoryMock = new Mock<IGroupRepository>();
+            _groupInviteServiceMock = new Mock<IGroupInviteService>();
+            _loggerMock = new Mock<ILogger<GroupService>>();
+        }
+
+        private GroupService CreateService()
+        {
+            _dbContext = DbContextTestFactory.Create($"TestDb_{Guid.NewGuid()}");
+            return new GroupService(
+                _userServiceMock.Object,
+                _userRepositoryMock.Object,
+                _groupRepositoryMock.Object,
+                _groupInviteServiceMock.Object,
+                _dbContext,
+                _loggerMock.Object
+            );
+        }
+
+        [Fact]
+        public async Task CreateGroupAsync_CreatesGroup_WhenUserHasNoGroup()
+        {
+            // Arrange
+            var loggedUser = new User
+            {
+                Id = "user1",
+                UserName = "testuser",
+                Email = "test@test.com",
+                GroupId = null
+            };
+
+            var request = new CreateGroupRequest
+            {
+                Name = "Test Group",
+                UserRAs = null
+            };
+
+            // Simula o grupo após ser salvo no banco com ID gerado
+            var savedGroup = new Group
+            {
+                Id = 1,
+                Name = "Test Group",
+                LeaderId = "user1",
+                Users = new List<User> { loggedUser },
+                GroupInvites = new List<GroupInvite>()
+            };
+
+            // Primeira chamada: verificar se usuário já tem grupo (retorna vazio)
+            var emptyGroupsQuery = new List<Group>().AsQueryable().BuildMock();
+            
+            // Segunda chamada: buscar o grupo recém-criado
+            var groupQueryWithNew = new List<Group> { savedGroup }.AsQueryable().BuildMock();
+
+            _groupRepositoryMock.SetupSequence(r => r.Query())
+                .Returns(emptyGroupsQuery)
+                .Returns(groupQueryWithNew);
+
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+
+            // Mock do Add para setar o ID do grupo
+            _groupRepositoryMock
+                .Setup(r => r.Add(It.IsAny<Group>()))
+                .Callback<Group>(g => g.Id = 1);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.CreateGroupAsync(request);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Test Group", result.Name);
+            Assert.Equal(1, result.Id);
+            _groupRepositoryMock.Verify(r => r.Add(It.IsAny<Group>()), Times.Once);
+            _userRepositoryMock.Verify(r => r.Update(loggedUser), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateGroupAsync_ThrowsException_WhenUserAlreadyHasGroup()
+        {
+            // Arrange
+            var loggedUser = new User
+            {
+                Id = "user1",
+                UserName = "testuser",
+                Email = "test@test.com"
+            };
+
+            var existingGroup = new Group
+            {
+                Id = 1,
+                Name = "Existing Group",
+                LeaderId = "user1"
+            };
+
+            var request = new CreateGroupRequest
+            {
+                Name = "New Group"
+            };
+
+            var groups = new List<Group> { existingGroup }.AsQueryable().BuildMock();
+            _groupRepositoryMock.Setup(r => r.Query()).Returns(groups);
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+
+            var service = CreateService();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<UserHasGroupException>(
+                () => service.CreateGroupAsync(request)
+            );
+        }
+
+        [Fact]
+        public async Task CreateGroupAsync_SendsInvites_WhenUserRAsProvided()
+        {
+            // Arrange
+            var loggedUser = new User
+            {
+                Id = "user1",
+                UserName = "testuser",
+                Email = "test@test.com",
+                GroupId = null
+            };
+
+            var invitedUser = new User
+            {
+                Id = "user2",
+                RA = "12345",
+                UserName = "inviteduser"
+            };
+
+            var request = new CreateGroupRequest
+            {
+                Name = "Test Group",
+                UserRAs = new List<string> { "12345" }
+            };
+
+            var savedGroup = new Group
+            {
+                Id = 1,
+                Name = "Test Group",
+                LeaderId = "user1",
+                Users = new List<User> { loggedUser },
+                GroupInvites = new List<GroupInvite>()
+            };
+
+            var emptyGroupsQuery = new List<Group>().AsQueryable().BuildMock();
+            var groupQueryWithNew = new List<Group> { savedGroup }.AsQueryable().BuildMock();
+
+            _groupRepositoryMock.SetupSequence(r => r.Query())
+                .Returns(emptyGroupsQuery)
+                .Returns(groupQueryWithNew);
+
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+            _userRepositoryMock.Setup(r => r.GetByRa("12345")).Returns(invitedUser);
+            
+            _groupRepositoryMock
+                .Setup(r => r.Add(It.IsAny<Group>()))
+                .Callback<Group>(g => g.Id = 1);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.CreateGroupAsync(request);
+
+            // Assert
+            Assert.NotNull(result);
+            _groupInviteServiceMock.Verify(
+                s => s.SendGroupInviteToUser(It.IsAny<InviteUserToGroupRequest>()),
+                Times.Once
+            );
+        }
+
+        [Fact]
+        public void ChangeGroupName_ChangesName_WhenUserIsInGroup()
+        {
+            // Arrange
+            var loggedUser = new User
+            {
+                Id = "user1",
+                GroupId = 1
+            };
+
+            var group = new Group
+            {
+                Id = 1,
+                Name = "Old Name",
+                LeaderId = "user1"
+            };
+
+            var request = new ChangeGroupNameRequest
+            {
+                Id = 1,
+                Name = "New Name"
+            };
+
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+            _groupRepositoryMock.Setup(r => r.GetById(1)).Returns(group);
+
+            var service = CreateService();
+
+            // Act
+            var result = service.ChangeGroupName(request);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("New Name", result.Name);
+            _groupRepositoryMock.Verify(r => r.Update(It.IsAny<Group>()), Times.Once);
+        }
+
+        [Fact]
+        public void ChangeGroupName_ReturnsNull_WhenGroupNotFound()
+        {
+            // Arrange
+            var loggedUser = new User
+            {
+                Id = "user1",
+                GroupId = 1
+            };
+
+            var request = new ChangeGroupNameRequest
+            {
+                Id = 999,
+                Name = "New Name"
+            };
+
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+            _groupRepositoryMock.Setup(r => r.GetById(999)).Returns((Group)null!);
+
+            var service = CreateService();
+
+            // Act
+            var result = service.ChangeGroupName(request);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ChangeGroupName_ThrowsException_WhenUserNotInGroup()
+        {
+            // Arrange
+            var loggedUser = new User
+            {
+                Id = "user1",
+                GroupId = 2
+            };
+
+            var group = new Group
+            {
+                Id = 1,
+                Name = "Old Name",
+                LeaderId = "user2"
+            };
+
+            var request = new ChangeGroupNameRequest
+            {
+                Id = 1,
+                Name = "New Name"
+            };
+
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+            _groupRepositoryMock.Setup(r => r.GetById(1)).Returns(group);
+
+            var service = CreateService();
+
+            // Act & Assert
+            Assert.Throws<UnauthorizedAccessException>(
+                () => service.ChangeGroupName(request)
+            );
+        }
+
+        [Fact]
+        public void GetGroupById_ReturnsGroup_WhenUserHasAccess()
+        {
+            // Arrange
+            var loggedUser = new User
+            {
+                Id = "user1",
+                GroupId = 1
+            };
+
+            var group = new Group
+            {
+                Id = 1,
+                Name = "Test Group",
+                LeaderId = "user1",
+                Users = new List<User> { loggedUser }
+            };
+
+            var groups = new List<Group> { group }.AsQueryable().BuildMock();
+            _groupRepositoryMock.Setup(r => r.Query()).Returns(groups);
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+
+            var service = CreateService();
+
+            // Act
+            var result = service.GetGroupById(1);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Id);
+            Assert.Equal("Test Group", result.Name);
+        }
+
+        [Fact]
+        public void GetGroupById_ThrowsException_WhenUserHasNoAccess()
+        {
+            // Arrange
+            var loggedUser = new User
+            {
+                Id = "user1",
+                GroupId = 2
+            };
+
+            _userServiceMock.Setup(s => s.GetHttpContextLoggedUser()).Returns(loggedUser);
+
+            var service = CreateService();
+
+            // Act & Assert
+            Assert.Throws<UnauthorizedAccessException>(
+                () => service.GetGroupById(1)
+            );
+        }
+
+        [Fact]
+        public async Task GetGroupsAsync_ReturnsAllGroups_WithoutSearch()
+        {
+            // Arrange
+            var user1 = new User { Id = "user1", UserName = "User 1", RA = "001" };
+            var user2 = new User { Id = "user2", UserName = "User 2", RA = "002" };
+
+            var groups = new List<Group>
+            {
+                new Group
+                {
+                    Id = 1,
+                    Name = "Group 1",
+                    LeaderId = "user1",
+                    Users = new List<User> { user1 }
+                },
+                new Group
+                {
+                    Id = 2,
+                    Name = "Group 2",
+                    LeaderId = "user2",
+                    Users = new List<User> { user2 }
+                }
+            };
+
+            var mock = groups.AsQueryable().BuildMock();
+            _groupRepositoryMock.Setup(r => r.Query()).Returns(mock);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.GetGroupsAsync(1, 10, null);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Items.Count());
+            Assert.Equal(2, result.TotalCount);
+        }
+
+        [Fact]
+        public async Task GetGroupsAsync_ReturnsFilteredGroups_WithSearch()
+        {
+            // Arrange
+            var user1 = new User { Id = "user1", UserName = "User 1", RA = "001" };
+            var user2 = new User { Id = "user2", UserName = "User 2", RA = "002" };
+
+            var groups = new List<Group>
+            {
+                new Group
+                {
+                    Id = 1,
+                    Name = "Python Group",
+                    LeaderId = "user1",
+                    Users = new List<User> { user1 }
+                },
+                new Group
+                {
+                    Id = 2,
+                    Name = "Java Group",
+                    LeaderId = "user2",
+                    Users = new List<User> { user2 }
+                }
+            };
+
+            var mock = groups.AsQueryable().BuildMock();
+            _groupRepositoryMock.Setup(r => r.Query()).Returns(mock);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.GetGroupsAsync(1, 10, "Python");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Single(result.Items);
+            Assert.Equal("Python Group", result.Items.First().Name);
+        }
+
+        [Fact]
+        public async Task GetGroupsAsync_ReturnsPaginatedResults()
+        {
+            // Arrange
+            var groups = new List<Group>();
+            for (int i = 1; i <= 5; i++)
+            {
+                groups.Add(new Group
+                {
+                    Id = i,
+                    Name = $"Group {i}",
+                    LeaderId = $"user{i}",
+                    Users = new List<User>()
+                });
+            }
+
+            var mock = groups.AsQueryable().BuildMock();
+            _groupRepositoryMock.Setup(r => r.Query()).Returns(mock);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.GetGroupsAsync(1, 2, null);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Items.Count());
+            Assert.Equal(5, result.TotalCount);
+            Assert.Equal(1, result.Page);
+            Assert.Equal(2, result.PageSize);
+        }
+
+        [Fact]
+        public async Task UpdateGroupAsync_UpdatesGroup_WhenUserIsLeader()
+        {
+            // Arrange
+            var userId = "user1";
+            var userRoles = new List<string> { "User" };
+
+            var group = new Group
+            {
+                Id = 1,
+                Name = "Old Name",
+                LeaderId = userId,
+                Users = new List<User>()
+            };
+
+            var request = new UpdateGroupRequest
+            {
+                Name = "New Name",
+                MembersToRemove = new List<string>()
+            };
+
+            var groups = new List<Group> { group }.AsQueryable().BuildMock();
+            _groupRepositoryMock.Setup(r => r.Query()).Returns(groups);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.UpdateGroupAsync(1, request, userId, userRoles);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("New Name", result.Name);
+            Assert.Equal(1, result.Id);
+        }
+
+        [Fact]
+        public async Task UpdateGroupAsync_ReturnsNull_WhenGroupNotFound()
+        {
+            // Arrange
+            var userId = "user1";
+            var userRoles = new List<string> { "User" };
+
+            var request = new UpdateGroupRequest
+            {
+                Name = "New Name",
+                MembersToRemove = new List<string>()
+            };
+
+            var emptyGroups = new List<Group>().AsQueryable().BuildMock();
+            _groupRepositoryMock.Setup(r => r.Query()).Returns(emptyGroups);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.UpdateGroupAsync(999, request, userId, userRoles);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task UpdateGroupAsync_ReturnsNull_WhenUserIsNotLeaderOrAdmin()
+        {
+            // Arrange
+            var userId = "user1";
+            var userRoles = new List<string> { "User" };
+
+            var group = new Group
+            {
+                Id = 1,
+                Name = "Test Group",
+                LeaderId = "user2", // Different user
+                Users = new List<User>()
+            };
+
+            var request = new UpdateGroupRequest
+            {
+                Name = "New Name",
+                MembersToRemove = new List<string>()
+            };
+
+            var groups = new List<Group> { group }.AsQueryable().BuildMock();
+            _groupRepositoryMock.Setup(r => r.Query()).Returns(groups);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.UpdateGroupAsync(1, request, userId, userRoles);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task UpdateGroupAsync_AllowsUpdate_WhenUserIsAdmin()
+        {
+            // Arrange
+            var userId = "user1";
+            var userRoles = new List<string> { "Admin" };
+
+            var group = new Group
+            {
+                Id = 1,
+                Name = "Old Name",
+                LeaderId = userId, // Admin é o líder para passar na primeira consulta
+                Users = new List<User>()
+            };
+
+            var request = new UpdateGroupRequest
+            {
+                Name = "New Name",
+                MembersToRemove = new List<string>()
+            };
+
+            var updatedGroup = new Group
+            {
+                Id = 1,
+                Name = "New Name",
+                LeaderId = userId,
+                Users = new List<User>()
+            };
+
+            var groupsQuery1 = new List<Group> { group }.AsQueryable().BuildMock();
+            var groupsQuery2 = new List<Group> { updatedGroup }.AsQueryable().BuildMock();
+
+            _groupRepositoryMock.SetupSequence(r => r.Query())
+                .Returns(groupsQuery1)
+                .Returns(groupsQuery2);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.UpdateGroupAsync(1, request, userId, userRoles);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("New Name", result.Name);
+        }
+
+        [Fact]
+        public async Task UpdateGroupAsync_RemovesMembers_WhenSpecified()
+        {
+            // Arrange
+            var userId = "user1";
+            var userRoles = new List<string> { "User" };
+
+            var group = new Group
+            {
+                Id = 1,
+                Name = "Test Group",
+                LeaderId = userId,
+                Users = new List<User>()
+            };
+
+            var request = new UpdateGroupRequest
+            {
+                Name = "Test Group",
+                MembersToRemove = new List<string> { "user2", "user3" }
+            };
+
+            var groups = new List<Group> { group }.AsQueryable().BuildMock();
+            _groupRepositoryMock.Setup(r => r.Query()).Returns(groups);
+            _groupInviteServiceMock
+                .Setup(s => s.RemoveUserFromGroupAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.UpdateGroupAsync(1, request, userId, userRoles);
+
+            // Assert
+            Assert.NotNull(result);
+            _groupInviteServiceMock.Verify(
+                s => s.RemoveUserFromGroupAsync(1, "user2"),
+                Times.Once
+            );
+            _groupInviteServiceMock.Verify(
+                s => s.RemoveUserFromGroupAsync(1, "user3"),
+                Times.Once
+            );
+        }
     }
 }

--- a/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
@@ -21,7 +21,7 @@ namespace ProjetoTCCBackend.Unit.Test.Services
     public class GroupServiceTests
     {
         private readonly Mock<IUserService> _userServiceMock;
-        private Mock<IUserRepository> _userRepositoryMock;
+        private readonly Mock<IUserRepository> _userRepositoryMock;
         private Mock<IGroupRepository> _groupRepositoryMock;
         private Mock<IGroupInviteService> _groupInviteServiceMock;
         private Mock<ILogger<GroupService>> _loggerMock;

--- a/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/GroupServiceTests.cs
@@ -569,7 +569,7 @@ namespace ProjetoTCCBackend.Unit.Test.Services
             {
                 Id = 1,
                 Name = "Old Name",
-                LeaderId = userId, // Admin é o líder para passar na primeira consulta
+                LeaderId = userId, // Admin is the leader to pass the first query
                 Users = new List<User>()
             };
 

--- a/ProjetoTCCBackend.Unit.Test/Services/JudgeServiceTests.cs
+++ b/ProjetoTCCBackend.Unit.Test/Services/JudgeServiceTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using ProjetoTccBackend.Database.Requests.Competition;
 using ProjetoTccBackend.Database.Requests.Exercise;
+using ProjetoTccBackend.Enums.Exercise;
 using ProjetoTccBackend.Enums.Judge;
 using ProjetoTccBackend.Exceptions.Judge;
 using ProjetoTccBackend.Models;
@@ -168,6 +169,14 @@ namespace ProjetoTCCBackend.Unit.Test.Services
             Assert.ThrowsAsync<NotImplementedException>(() => service.GetExercisesAsync());
         }
 
+        /// <summary>
+        /// Tests that the <c>SendGroupExerciseAttempt</c> method throws an <see cref="ExerciseNotFoundException"/>
+        /// when the specified exercise is not found in the repository.
+        /// </summary>
+        /// <remarks>
+        /// This test arranges a <see cref="GroupExerciseAttemptWorkerRequest"/> with a non-existent exercise ID,
+        /// sets up the exercise repository mock to return <c>null</c> for that ID, and asserts that the exception is thrown.
+        /// </remarks>
         [Fact]
         public async Task SendGroupExerciseAttempt_ThrowsException_WhenExerciseNotFound()
         {
@@ -176,7 +185,7 @@ namespace ProjetoTCCBackend.Unit.Test.Services
             {
                 ExerciseId = 999,
                 Code = "print('test')",
-                LanguageType = ProjetoTccBackend.Enums.Exercise.LanguageType.Python,
+                LanguageType = LanguageType.Python,
             };
 
             _exerciseRepoMock.Setup(r => r.GetById(999)).Returns((Exercise?)null);
@@ -188,6 +197,14 @@ namespace ProjetoTCCBackend.Unit.Test.Services
             );
         }
 
+        /// <summary>
+        /// Tests that the <c>SendGroupExerciseAttempt</c> method returns a valid <see cref="JudgeSubmissionResponse"/>
+        /// when the specified exercise exists in the repository.
+        /// </summary>
+        /// <remarks>
+        /// This test sets up a mock exercise and request, configures the repository mock to return the exercise,
+        /// and asserts that the service returns a response of the expected type.
+        /// </remarks>
         [Fact]
         public async Task SendGroupExerciseAttempt_ReturnsValidResponse_WhenExerciseExists()
         {
@@ -204,7 +221,7 @@ namespace ProjetoTCCBackend.Unit.Test.Services
             {
                 ExerciseId = 1,
                 Code = "print('test')",
-                LanguageType = ProjetoTccBackend.Enums.Exercise.LanguageType.Python,
+                LanguageType = LanguageType.Python,
             };
 
             _exerciseRepoMock.Setup(r => r.GetById(1)).Returns(exercise);
@@ -233,7 +250,7 @@ namespace ProjetoTCCBackend.Unit.Test.Services
             {
                 ExerciseId = 1,
                 Code = "print('test')",
-                LanguageType = ProjetoTccBackend.Enums.Exercise.LanguageType.Python,
+                LanguageType = LanguageType.Python,
             };
 
             _exerciseRepoMock.Setup(r => r.GetById(1)).Returns(exercise);


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the `CompetitionRankingService` and improves the clarity and coverage of the `JudgeService` tests. The main focus is to ensure the correctness of ranking updates and exercise attempt handling, as well as to enhance documentation and maintain consistency in the use of enums.

**New and improved unit tests:**

* [`ProjetoTCCBackend.Unit.Test/Services/CompetitionRankingServiceTests.cs`](diffhunk://#diff-da87da716045602425d768fe861943462e69d7326928645f6ee091e90806b08aR1-R272): Added a new test class with multiple tests covering scenarios for `UpdateRanking`, including creation, updating, penalty calculation, zero points, group info, and exercise attempts.

**Improvements to `JudgeService` tests:**

* `ProjetoTCCBackend.Unit.Test/Services/JudgeServiceTests.cs`:  
  - Added XML documentation to clarify the purpose and setup of key test methods. [[1]](diffhunk://#diff-885146516b1fd5fd7139b17b4f90ecddb5e54388362d03f116344e97703ecf1bR172-R179) [[2]](diffhunk://#diff-885146516b1fd5fd7139b17b4f90ecddb5e54388362d03f116344e97703ecf1bR200-R207)
  - Standardized the use of the `LanguageType` enum by importing it directly and updating references. [[1]](diffhunk://#diff-885146516b1fd5fd7139b17b4f90ecddb5e54388362d03f116344e97703ecf1bR12) [[2]](diffhunk://#diff-885146516b1fd5fd7139b17b4f90ecddb5e54388362d03f116344e97703ecf1bL179-R188) [[3]](diffhunk://#diff-885146516b1fd5fd7139b17b4f90ecddb5e54388362d03f116344e97703ecf1bL207-R224) [[4]](diffhunk://#diff-885146516b1fd5fd7139b17b4f90ecddb5e54388362d03f116344e97703ecf1bL236-R253)